### PR TITLE
Create PID-Motor encoder fixes

### DIFF
--- a/create_motor.cpp
+++ b/create_motor.cpp
@@ -13,6 +13,8 @@
 #include <kipr/time/time.h>
 #include <iostream>
 #include <iomanip>
+#include <fstream>
+#include <time.h>
 #include "create_motor.hpp"
 
 using namespace kp;
@@ -30,6 +32,7 @@ SyncPID CreateMotor::pid_provider[2] =
 };
 int CreateMotor::create_speed[2] = {0, 0};
 int CreateMotor::position_offsets[2] = {0, 0};
+int CreateMotor::current_raw_position[2] = {0, 0};
 int CreateMotor::current_position[2] = {0, 0};
 bool CreateMotor::pos_ctrl_active[2] = {false, false};
 int CreateMotor::accuracy[2] = {0, 0};
@@ -44,7 +47,8 @@ int CreateMotor::thread_consumers = 0;
 
 std::thread CreateMotor::controller_thread;
 
-
+char CreateMotor::file_path[64] = {0};
+bool CreateMotor::is_initialized = false;
 
 #define LOOP_DELAY 2 // ms
 
@@ -53,6 +57,7 @@ void CreateMotor::globalCreateConnect()
 {
     std::lock_guard lock(create_access_mutex);
     create_connect(); // always returns 0
+    set_create_baud_rate(Baud57600);
     create_connected_flag = true;
 }
 
@@ -66,12 +71,43 @@ void CreateMotor::globalCreateDisconnect()
 // the create should never be communicated with from any thread other than this one
 void CreateMotor::controllerThreadFn()
 {
+    std::time_t t = std::time(nullptr);
+    std::strftime(file_path, sizeof(file_path), "/home/access/logs/pid_controller/pid_%m_%Y__%H_%M_%S.log", std::localtime(&t));
+
+    std::cout << "motor log path: " << file_path << std::endl;
+
+    std::ofstream log_stream(file_path);
+
+    char buffer[100];
+    short int counter = 0;
     while (thread_consumers)
     {
+        counter++;
         updatePositions();
         last_position_update = systime();
         int nr_motors = 2;
         int changed = false;
+ 
+        // log to file
+        snprintf(buffer, 99, "%i;%i;%i;%i\n", (int)current_position[0], (int)current_position[1], (int)current_raw_position[0], current_raw_position[1]);
+
+        try
+        {
+            log_stream << buffer;
+        }
+        catch (const std::exception &e)
+        {
+            std::cout << "log write error: " << e.what() << std::endl;
+        }
+
+        if (counter > 20)
+        {
+            counter = 0;
+            log_stream.flush();
+            is_initialized = true;
+        }
+
+ 
         for (int i = 0; i < nr_motors; i++)
         {
             if (!pos_ctrl_active[i]) continue;
@@ -101,6 +137,8 @@ void CreateMotor::controllerThreadFn()
         
         msleep(LOOP_DELAY);
     }
+
+    log_stream.close();
 }
 
 void CreateMotor::updatePositions()
@@ -109,8 +147,40 @@ void CreateMotor::updatePositions()
     short l, r;
     _create_get_raw_encoders(&l, &r);
     //std::cout << std::this_thread::get_id() << " Readpos l=" << l << ", r=" << r << std::endl;
+
+    // filter spikes
+    if (is_initialized)
+    {
+        if (abs(l - current_raw_position[0]) > 500)
+        {
+            std::cout << "motor 1 spike, resetting!  ";
+            int diff = current_raw_position[0] - l ;
+
+            std::cout << "last offset: " << position_offsets[0] << ", difference: " << diff;
+
+            position_offsets[0] -= diff;
+
+            std::cout << ", now: " << position_offsets[0] << std::endl;
+        }
+
+        if (abs(r - current_raw_position[1]) > 500)
+        {
+            std::cout << "motor 2 spike, resetting!  ";
+            int diff = current_raw_position[1] - r;
+            std::cout << "last offset: " << position_offsets[1] << ", difference: " << diff;
+
+            position_offsets[1] -= diff;
+
+            std::cout << ", now: " << position_offsets[1] << std::endl;
+        }
+    }
+
+    // set position variables
     current_position[0] = l - position_offsets[0];
     current_position[1] = r - position_offsets[1];
+
+    current_raw_position[0] = l;
+    current_raw_position[1] = r;
 }
 
 

--- a/create_motor.hpp
+++ b/create_motor.hpp
@@ -31,6 +31,7 @@ namespace kp
         static SyncPID pid_provider[2];
         static int create_speed[2];
         static int position_offsets[2];
+        static int current_raw_position[2];
         static int current_position[2];
         static bool pos_ctrl_active[2];
         static int accuracy[2];
@@ -56,6 +57,9 @@ namespace kp
 
         // reads encoder values and stores them in internal array
         static void updatePositions();
+
+        static char file_path[64];
+        static bool is_initialized;
 
     public:
         static void globalCreateConnect();

--- a/smooth_servo.cpp
+++ b/smooth_servo.cpp
@@ -48,6 +48,10 @@ void SmoothServo::controllerThreadFn()
 SmoothServo::SmoothServo(int port, int initial_pos)
     : Servo(port)
 {
+    if (initial_pos == -1)
+    {
+        initial_pos = Servo::position();
+    }
     start_pos = initial_pos;
     curr_pos = initial_pos;
     set_pos = initial_pos;
@@ -136,4 +140,9 @@ double SmoothServo::getPercentCompleted()
 void SmoothServo::waitUntilComleted()
 {
     while (!(getPercentCompleted() > 99)) { msleep(10); };
+}
+
+int SmoothServo::getServoPosition()
+{
+    return Servo::position();
 }

--- a/smooth_servo.hpp
+++ b/smooth_servo.hpp
@@ -35,7 +35,7 @@ namespace kp
             void controllerThreadFn();
 
         public:
-            SmoothServo(int port, int initial_pos = 1024);
+            SmoothServo(int port, int initial_pos = -1);
             ~SmoothServo();
 
             void disable();
@@ -48,6 +48,7 @@ namespace kp
 
             void setPosition(int position);
             void setPosition(int position, int speed);
+            int getServoPosition();
             int getSetPosition();
             int position();
 


### PR DESCRIPTION
added a spike filter that removes any inconsistencies in the create motor-encoders, as well as the integer-overflow problem from the raw encoders.